### PR TITLE
Switch Cursor when hovering over title on appbar

### DIFF
--- a/src/components/AppBarMenu/AppBarMenu.scss
+++ b/src/components/AppBarMenu/AppBarMenu.scss
@@ -7,7 +7,7 @@
 }
 
 .TitleSpan {
-  cursor: default;
+  cursor: pointer;
 }
 
 body {


### PR DESCRIPTION
Cursor now appears as a pointer when hovering over appbar. This displays that there's a link that the user can click